### PR TITLE
Expose image dialog open status to root presentation div (closes #7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presentation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "presentation",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "reveal.js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presentation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Build slideshow presentations from within Roam!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/components/Presentation.tsx
+++ b/src/components/Presentation.tsx
@@ -526,6 +526,9 @@ const ContentSlide = ({
       const target = e.target as HTMLElement;
       if (target.tagName === "IMG") {
         setImageDialogSrc((target as HTMLImageElement).src);
+        document
+          .getElementById("roamjs-presentation-container")
+          .classList.add("image-dialog-open");
       } else if (collapsible) {
         const className = target.className;
         if (className.includes("roamjs-collapsible-caret")) {
@@ -558,10 +561,12 @@ const ContentSlide = ({
     },
     [collapsible, setImageDialogSrc]
   );
-  const onDialogClose = useCallback(
-    () => setImageDialogSrc(""),
-    [setImageDialogSrc]
-  );
+  const onDialogClose = useCallback(() => {
+    setImageDialogSrc(""),
+      document
+        .getElementById("roamjs-presentation-container")
+        .classList.remove("image-dialog-open");
+  }, [setImageDialogSrc]);
 
   const props = {
     ...(animate ? { "data-auto-animate": true } : {}),


### PR DESCRIPTION
This will allow the end user to style the entire presentation based on image dialog open status, ie, add background color / blur.

Might not be ideal to use `document.getElementById`, but `imageDialogSrc` doesn't seem accessible in that scope.
Maybe there is a better way to do with with reveal.js' API?

@dvargas92495 